### PR TITLE
Initializing variables, updating coding standards

### DIFF
--- a/sharing-count.js
+++ b/sharing-count.js
@@ -1,21 +1,36 @@
-(function($, undefined) {
-	function update_mpworg_widget(response) {
-		var id = WPCOM_sharing_counts[response.url];
-		if (id === undefined || !response.votes) {
-			return;
-		}
-		$('#sharing-mwporg-' + id + ' span').append('<span class="share-count">' + response.votes + '</span>');
-	}
+(function( $ ) {
+
+	// Initialize to an empty until it's populated by the response
+	var WPCOM_sharing_counts = [];
 
 	window.update_mpworg_widget = update_mpworg_widget;
 
-	$(function() {
-		for ( var url in WPCOM_sharing_counts ) {
-			var id = WPCOM_sharing_counts[url];
-			if ($('#sharing-mwporg-' + id).length) {
-				// Only send a request if a matching widget is found
-				jQuery.getScript( 'http://managewp.org/share/frame/small?url=' + encodeURIComponent(url) + '&callback=update_mpworg_widget' );
-			}
+	function update_mpworg_widget( response ) {
+
+		var id = WPCOM_sharing_counts[ response.url ];
+
+		if ( undefined === id || ! response.votes) {
+			return;
 		}
+
+		$('#sharing-mwporg-' + id + ' span').append( '<span class="share-count">' + response.votes + '</span>' );
+
+	}
+
+	$(function() {
+
+		var url, id;
+
+		for ( url in WPCOM_sharing_counts ) {
+
+			id = WPCOM_sharing_counts[ url ];
+
+			// Only send a request if a matching widget is found
+			if ( $( '#sharing-mwporg-' + id ).length ) {
+				$.getScript( 'http://managewp.org/share/frame/small?url=' + encodeURIComponent( url ) + '&callback=update_mpworg_widget' );
+			}
+
+		}
+
 	});
-})(jQuery);
+})( jQuery );


### PR DESCRIPTION
- WPCOM_sharing_counts throws an error with other plugins if the sharer isn't on a page, so an empty array is being initialized
- Updating the code to follow the JavaScript coding standards
