### PR TITLE
Fixes the global variable shadowing

### DIFF
--- a/sharing-count.js
+++ b/sharing-count.js
@@ -1,7 +1,7 @@
 (function( $ ) {
 
 	// Initialize to an empty until it's populated by the response
-	var WPCOM_sharing_counts = [];
+	WPCOM_sharing_counts = WPCOM_sharing_counts || [];
 
 	window.update_mpworg_widget = update_mpworg_widget;
 


### PR DESCRIPTION
Before the global WPCOM_sharing_counts variable was being shadowed by the local one, hence none of the URLs were loaded. Also added a check to make sure the global variable is not overwritten. At the moment of creating this PR ManageWP.org was not responding, so I couldn't check if the counts work, though.
